### PR TITLE
Add Meson build

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2024 L. E. Segovia <amy@amyspark.me>
+# SPDX-License-Identifier: BSD-3-Clause
+
+doxyfile_cfg = {
+	'PACKAGE': meson.project_name(),
+	'VERSION': meson.project_version(),
+	'top_srcdir': meson.project_source_root(),
+}
+
+doxyfile = configure_file(
+	input: files(
+		'Doxyfile.in'
+	),
+	output: 'libftdi.dox',
+	configuration: doxyfile_cfg
+)
+
+doxyfile = configure_file(
+	command: [
+		generate_doxyfile,
+		'--strip', meson.current_source_dir(), meson.current_build_dir(),
+		'--output', '@OUTPUT@',
+		'@OUTDIR@',
+		'@INPUT@',
+	],
+	input: doxyfile,
+	output: 'Doxyfile',
+)
+
+doxyfile_xml = configure_file(
+	input: files(
+		'Doxyfile.xml.in'
+	),
+	output: 'Doxyfile.xml',
+	configuration: doxyfile_cfg
+)
+
+docs = custom_target(
+	'docs',
+	input: doxyfile,
+	output: 'html',
+	command: [
+		doxygen, '@INPUT@'
+	],
+	depend_files: doxyfile_xml,
+	console: true,
+	install: true,
+	install_dir: get_option('datadir') / meson.project_name(),
+)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2024 L. E. Segovia <amy@amyspark.me>
+# SPDX-License-Identifier: BSD-3-Clause
+
+examples = [
+	'simple',
+	'bitbang',
+	'bitbang2',
+	'bitbang_cbus',
+	'bitbang_ft2232',
+	'find_all',
+	'serial_test',
+	'baud_test',
+	'stream_test',
+	'eeprom',
+	'async',
+	'purge_test',
+]
+
+examples_include_directories = include_directories('.')
+
+foreach example : examples
+	executable(
+		example,
+		files(
+			'@0@.c'.format(example),
+		),
+		include_directories: examples_include_directories,
+		dependencies: ftdi1_dep,
+		install: false,
+	)
+endforeach
+
+examples_pp = [
+	'find_all_pp'
+]
+
+foreach example : examples_pp
+	executable(
+		example,
+		files(
+			'@0@.cpp'.format(example),
+		),
+		include_directories: examples_include_directories,
+		dependencies: ftdipp1_dep,
+		install: false,
+	)
+endforeach

--- a/ftdi_eeprom/meson.build
+++ b/ftdi_eeprom/meson.build
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2024 L. E. Segovia <amy@amyspark.me>
+# SPDX-License-Identifier: BSD-3-Clause
+
+warning('''
+	The EEPROM programmer is licensed under GPL 2 (not any later)''')
+
+eeprom_major_version = 0
+eeprom_minor_version = 17
+eeprom_version = f'@eeprom_major_version@.@eeprom_minor_version@'
+
+eeprom_include_directories = include_directories('.')
+
+ftdi_eeprom_version = configure_file(
+	input: 'ftdi_eeprom_version.h.in',
+	output: 'ftdi_eeprom_version.h',
+	configuration: {
+		'EEPROM_MAJOR_VERSION': eeprom_major_version,
+		'EEPROM_MINOR_VERSION': eeprom_minor_version,
+		'EEPROM_VERSION_STRING': eeprom_version,
+	}
+)
+
+ftdi_eeprom = executable(
+	'ftdi_eeprom',
+	files(
+		'main.c',
+	),
+	dependencies: [confuse, libintl, ftdi1_dep],
+	install: true,
+)
+
+install_data(
+	files(
+		'example.conf'
+	),
+	install_dir: get_option('datadir') / 'doc',
+)

--- a/ftdipp/meson.build
+++ b/ftdipp/meson.build
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2024 L. E. Segovia <amy@amyspark.me>
+# SPDX-License-Identifier: BSD-3-Clause
+
+include_directories = include_directories('.')
+
+ftdipp1_sources = files(
+	'ftdi.cpp',
+)
+
+ftdipp1_headers = files(
+	'ftdi.hpp',
+)
+
+ftdipp1_lib = library(
+	'ftdipp1',
+	ftdipp1_sources,
+	dependencies: [boost, libusb, ftdi1_dep],
+	version: version_fixup,
+	soversion: 3,
+	install: true,
+)
+
+ftdipp1_dep = declare_dependency(
+	link_with: ftdipp1_lib,
+	include_directories: include_directories,
+)
+
+meson.override_dependency('libftdipp1', ftdipp1_dep)
+
+install_headers(
+	ftdipp1_headers,
+	subdir: 'libftdipp1',
+)
+

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2024 L. E. Segovia <amy@amyspark.me>
+# SPDX-License-Identifier: BSD-3-Clause
+
+project(
+	'libftdi1',
+	'c', 'cpp',
+	version: '1.5',
+	default_options: [
+		'buildtype=debugoptimized',
+		'c_std=c11',
+		'cpp_std=c++11',
+	],
+	meson_version: '>= 0.59',
+	license: 'LGPL-2.1 OR (LGPL-2.1 AND GPL-2.0)',
+)
+
+pkg = import('pkgconfig')
+
+cc = meson.get_compiler('c')
+
+version = meson.project_version().split('.')
+
+version_fixup = '@0@.@1@.0'.format(version[0].to_int() + 1, version[1])
+
+if get_option('optimization') == '0'
+	add_project_arguments('-DDEBUG', language: ['c', 'cpp'])
+endif
+
+ftdipp = get_option('ftdipp')
+tests = get_option('tests')
+ftdi_eeprom = get_option('ftdi_eeprom')
+examples = get_option('examples')
+
+libusb = dependency('libusb-1.0')
+doxygen = find_program('doxygen', required: get_option('docs'), disabler: true, native: true)
+generate_doxyfile = find_program('meson/generate_doxyfile.py', required: true, native: true)
+boost = dependency('boost', components: ['headers'], required: ftdipp, disabler: true)
+confuse = dependency('confuse', required: ftdi_eeprom, disabler: true)
+libintl = dependency('intl', required: false)
+boost_test = dependency('boost', components: ['unit_test_framework'], required: tests, disabler: true)
+
+subdir('doc')
+
+subdir('src')
+
+if ftdipp.allowed()
+	# Meson does not allow subprojects in random directories
+	subdir('ftdipp')
+endif
+
+# if python_bindings.allowed()
+# 	subdir('python')
+# endif
+
+if ftdi_eeprom.allowed()
+	subdir('ftdi_eeprom')
+endif
+
+# MSVC lacks unistd.h
+if examples.require(host_machine.system() != 'windows',
+					error_message: 'Examples cannot be built under Windows').allowed()
+	subdir('examples')
+endif
+
+subdir('packages')
+
+subdir('test')
+
+pkg.generate(
+	ftdi1_lib,
+	url: 'Intra2net AG <libftdi@developer.intra2net.com>',
+	description: 'Library to program and control the FTDI USB controller',
+)
+
+pkg.generate(
+	ftdipp1_lib,
+	url: 'Intra2net AG <libftdi@developer.intra2net.com>',
+	description: 'C++ wrapper for libftdi1',
+)
+
+libftdi1_config = configure_file(
+	input: 'libftdi1-config.in',
+	output: 'libftdi1-config',
+	configuration: {
+		'prefix': get_option('prefix'),
+		'exec_prefix': get_option('prefix') / get_option('bindir'),
+		'includedir': get_option('prefix') / get_option('includedir'),
+		'libdir': get_option('prefix') / get_option('libdir'),
+		'VERSION': meson.project_version(),
+		'LIBS': '',
+	}
+)
+
+install_data(
+	libftdi1_config,
+	install_dir: get_option('bindir'),
+	install_mode: 'rwxr-xr-x',
+)

--- a/meson/generate_doxyfile.py
+++ b/meson/generate_doxyfile.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023-2024 L. E. Segovia <amy@amyspark.me>
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+from argparse import ArgumentParser, FileType
+from io import StringIO
+from pathlib import Path
+import os
+
+def with_trailing(p: Path) -> str:
+	return f"{p.as_posix()}{'/' if p.is_dir() else ''}"
+
+if __name__ == '__main__':
+	parser = ArgumentParser(description='Create a Doxyfile for the whole project respecting Meson conventions')
+	parser.add_argument('--prelude', nargs='+', type=Path, help='Templates that will be copied to the file')
+	parser.add_argument('--strip', nargs='+', type=Path, help='Make paths inside this directory relative')
+	parser.add_argument('--example-path', nargs='+', type=Path, help='Directory that contains example code fragments')
+	parser.add_argument('--output', type=FileType('w', encoding='utf-8'), required=True, help='Write to this file')
+	parser.add_argument('root', type=Path, help='Root for the Doxygen output')
+	parser.add_argument('inputs', nargs='+', type=Path, help='Inputs for the Doxygen documentation')
+	args = parser.parse_args()
+
+	f = StringIO()
+
+	if args.prelude:
+		for file in args.prelude:
+			f.write(file.open(encoding='utf-8').read())
+	f.write('# MESON override OUTPUT_DIR\n')
+	f.write(f'OUTPUT_DIRECTORY       = {args.root.as_posix()}\n')
+	if args.strip:
+		paths_to_strip: str = ' '.join([f.as_posix() for f in args.strip])
+		f.write(f'STRIP_FROM_PATH += {paths_to_strip}\n')
+	if args.inputs:
+		inputs = ' '.join([f.as_posix() for f in args.inputs])
+		f.write(f'INPUT += {inputs}\n')
+	if args.example_path:
+		example_paths = ' '.join(map(with_trailing, args.example_path))
+		f.write(f'EXAMPLE_PATH += {example_paths}\n')
+
+	with args.output as output:
+		output.write(f.getvalue())

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,48 @@
+option('tests',
+	type: 'feature',
+	value: 'auto',
+	yield: true,
+	description: 'Build unit tests with Boost Unit Test framework'
+)
+
+option('docs',
+	type: 'feature',
+	value: 'auto',
+	yield: true,
+	description: 'Generate API documentation with Doxygen'
+)
+
+option('examples',
+	type: 'feature',
+	value: 'auto',
+	yield: true,
+	description: 'Build example programs'
+)
+
+option('ftdipp',
+	type: 'feature',
+	value: 'auto',
+	yield: true,
+	description: 'Build C++ binding library libftdi1++'
+)
+
+option('ftdi_eeprom',
+	type: 'feature',
+	value: 'auto',
+	yield: true,
+	description: 'Build ftdi_eeprom'
+)
+
+# option('python_bindings',
+# 	type: 'feature',
+# 	value: 'auto',
+# 	yield: true,
+# 	description: 'Build python bindings via swig'
+# )
+
+option('link_python_library',
+	type: 'feature',
+	value: 'auto',
+	yield: true,
+	description: 'Link against python libraries'
+)

--- a/packages/meson.build
+++ b/packages/meson.build
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2024 L. E. Segovia <amy@amyspark.me>
+# SPDX-License-Identifier: BSD-3-Clause
+
+install_data(
+	files(
+		'99-libftdi.rules',
+	),
+	install_dir: get_option('libdir') / 'udev' / 'rules.d',
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2024 L. E. Segovia <amy@amyspark.me>
+# SPDX-License-Identifier: BSD-3-Clause
+
+include_directories = include_directories('.')
+
+snapshot_version = 'unknown'
+
+git_describe = run_command(
+	find_program('git', required: false, disabler: true),
+	'--git-dir',
+	meson.project_source_root() / '.git',
+	'describe',
+	capture: true,
+	check: false
+)
+
+if git_describe.returncode() == 0
+	snapshot_version = git_describe.stdout().strip()
+	message('Detected git snapshot version: @0@'.format(snapshot_version))
+endif
+
+ftdi1_version = configure_file(
+	input: 'ftdi_version_i.h.in',
+	output: 'ftdi_version_i.h',
+	configuration: {
+		'MAJOR_VERSION': version[0].to_int(),
+		'MINOR_VERSION': version[1].to_int(),
+		'VERSION_STRING': meson.project_version(),
+		'SNAPSHOT_VERSION': snapshot_version,
+	}
+)
+
+ftdi1_sources = files(
+	'ftdi.c',
+)
+
+ftdi1_headers = files(
+	'ftdi.h',
+)
+
+ftdi1_lib = library(
+	'ftdi1',
+	[ftdi1_sources, ftdi1_version],
+	dependencies: libusb,
+	version: version_fixup,
+	soversion: 2,
+	install: true,
+)
+
+ftdi1_dep = declare_dependency(
+	link_with: ftdi1_lib,
+	include_directories: include_directories,
+)
+
+meson.override_dependency('libftdi1', ftdi1_dep)
+
+install_headers(
+	ftdi1_headers,
+	subdir: meson.project_name()
+)

--- a/subprojects/libusb.wrap
+++ b/subprojects/libusb.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://github.com/blackmagic-debug/libusb
+revision = v1.0.27-meson
+clone-recursive = false
+
+[provide]
+libusb-1.0 = libusb_dep

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 L. E. Segovia <amy@amyspark.me>
+# SPDX-License-Identifier: BSD-3-Clause
+
+cpp_tests_sources = files(
+	'basic.cpp',
+	'baudrate.cpp',
+)
+
+test_libftdi1 = executable(
+	'test_libftdi1',
+	dependencies: [ftdi1_dep, boost_test]
+)
+
+test(
+	'test_libftdi1',
+	test_libftdi1,
+)


### PR DESCRIPTION
Hi @dragonmux,

Hope you like this 🎁 . It's mostly a 1:1 port of the CMake toolchain, with the following exceptions:

- I skipped the Python bindings as the logic is hidden behind a CMake module, and I was not sure if they were useful for you.
- The `examples` component is gatekept so that it's skipped under Windows (they need `unistd.h` and `termios.h`).
- I added a patch of mine from the GStreamer's libvpx Meson wrap, to make Doxygen's output directory compliant with Meson's subproject system.

Please note the latter, your libusb wrap needs the same script applied as currently it overwrites everything in `meson.global_build_root() / 'api-1.0' ` (Doxygen builds relative to the `pwd`, which in this case is Ninja's working directory).